### PR TITLE
Add test cases for one side of Park on same line

### DIFF
--- a/lib/mbta.js
+++ b/lib/mbta.js
@@ -1,9 +1,35 @@
 'use strict';
 
-// Code here.
+const Lines = { Red: {
+  'South Station': 1,
+  'Park Street': 0,
+  'Kendall': 1,
+  'Central': 2,
+  'Harvard': 3,
+  'Porter': 4,
+  'Davis': 5,
+  'Alewife': 6
+}, Blue: {
+  'Government Center': 1,
+  'Park Street': 0,
+  'Boylston': 1,
+  'Arlington': 2,
+  'Copley': 3,
+  'Hynes': 4,
+  'Kenmore': 5
+}, Orange: {
+  'North Station': 2,
+  'Haymarket': 1,
+  'Park Street': 0,
+  'State': 1,
+  'Downtown Crossing': 2,
+  'Chinatown': 3,
+  'Back Bay': 4,
+  'Forest Hills': 5
+}};
 
 const stopsBetweenStations = (startLine, startStation, endLine, endStation) => {
-
+  return Lines[startLine][startStation] + Lines[endLine][endStation];
 };
 
 module.exports = {

--- a/lib/mbta.js
+++ b/lib/mbta.js
@@ -4,7 +4,7 @@
 //test cases, e.g., my solution totally fails for Harvard to to Porter (it would
 //return seven (7) stops rather than the correct 1)).
 const Lines = {
-  'South Station': 1,
+  'South Station': -1,
   'Park Street': 0,
   'Kendall': 1,
   'Central': 2,
@@ -12,14 +12,14 @@ const Lines = {
   'Porter': 4,
   'Davis': 5,
   'Alewife': 6,
-  'Government Center': 1,
+  'Government Center': -1,
   'Boylston': 1,
   'Arlington': 2,
   'Copley': 3,
   'Hynes': 4,
   'Kenmore': 5,
-  'North Station': 2,
-  'Haymarket': 1,
+  'North Station': -2,
+  'Haymarket': -1,
   'State': 1,
   'Downtown Crossing': 2,
   'Chinatown': 3,
@@ -28,7 +28,13 @@ const Lines = {
 };
 
 const stopsBetweenStations = (startLine, startStation, endLine, endStation) => {
-  return Lines[startStation] + Lines[endStation];
+  if (startLine === endLine) {
+    return Math.abs((Lines[startStation] - Lines[endStation]));
+  } else if (startLine !== endLine) {
+    return Math.abs(Lines[startStation]) + Math.abs(Lines[endStation]);
+  } else {
+    return 0;
+  }
 };
 
 module.exports = {

--- a/lib/mbta.js
+++ b/lib/mbta.js
@@ -1,8 +1,5 @@
 'use strict';
 
-//TODO redo this solution to deal with test cases that aren't present in the WDI
-//test cases, e.g., my solution totally fails for Harvard to to Porter (it would
-//return seven (7) stops rather than the correct 1)).
 const Lines = {
   'South Station': -1,
   'Park Street': 0,

--- a/lib/mbta.js
+++ b/lib/mbta.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const Lines = { Red: {
+//TODO redo this solution to deal with test cases that aren't present in the WDI
+//test cases, e.g., my solution totally fails for Harvard to to Porter (it would
+//return seven (7) stops rather than the correct 1)).
+const Lines = {
   'South Station': 1,
   'Park Street': 0,
   'Kendall': 1,
@@ -8,28 +11,24 @@ const Lines = { Red: {
   'Harvard': 3,
   'Porter': 4,
   'Davis': 5,
-  'Alewife': 6
-}, Blue: {
+  'Alewife': 6,
   'Government Center': 1,
-  'Park Street': 0,
   'Boylston': 1,
   'Arlington': 2,
   'Copley': 3,
   'Hynes': 4,
-  'Kenmore': 5
-}, Orange: {
+  'Kenmore': 5,
   'North Station': 2,
   'Haymarket': 1,
-  'Park Street': 0,
   'State': 1,
   'Downtown Crossing': 2,
   'Chinatown': 3,
   'Back Bay': 4,
   'Forest Hills': 5
-}};
+};
 
 const stopsBetweenStations = (startLine, startStation, endLine, endStation) => {
-  return Lines[startLine][startStation] + Lines[endLine][endStation];
+  return Lines[startStation] + Lines[endStation];
 };
 
 module.exports = {

--- a/spec/mbta.spec.js
+++ b/spec/mbta.spec.js
@@ -14,6 +14,10 @@ describe('mbta', () => {
       expect(mbta.stopsBetweenStations('Red', 'South Station', 'Red', 'Alewife')).toBe(7);
     });
 
+    it('goes from "Central" to "Porter"', () => {
+      expect(mbta.stopsBetweenStations('Red', 'Central', 'Red', 'South Station')).toBe(2);
+    });
+
   });
 
   describe('Green Line', () => {
@@ -24,6 +28,10 @@ describe('mbta', () => {
 
     it('goes from "Copley" to "Haymarket"', () => {
       expect(mbta.stopsBetweenStations('Green', 'Kenmore', 'Green', 'Government Center')).toBe(6);
+    });
+
+    it('goes from "Kenmore" to "Arlington"', () => {
+      expect(mbta.stopsBetweenStations('Green', 'Kenmore', 'Green', 'Arlington')).toBe(3);
     });
 
   });
@@ -38,6 +46,10 @@ describe('mbta', () => {
     it('goes from "Forest Hills" to "North Station"', () => {
       expect(mbta.stopsBetweenStations('Orange', 'Forest Hills', 'Orange',
                                        'North Station')).toBe(7);
+    });
+
+    it('goes from "State" to "Downtown Crossing"', () => {
+      expect(mbta.stopsBetweenStations('Orange', 'State', 'Orange', 'Downtown Crossing')).toBe(1);
     });
 
   });

--- a/spec/mbta.spec.js
+++ b/spec/mbta.spec.js
@@ -15,7 +15,7 @@ describe('mbta', () => {
     });
 
     it('goes from "Central" to "Porter"', () => {
-      expect(mbta.stopsBetweenStations('Red', 'Central', 'Red', 'South Station')).toBe(2);
+      expect(mbta.stopsBetweenStations('Red', 'Central', 'Red', 'Porter')).toBe(2);
     });
 
   });


### PR DESCRIPTION
--Add three new test cases, one for each MBTA line, that tests for
  stops that are on the same "side" of Park Street.
