### PR TITLE
Mbta spec fix

### DIFF
--- a/lib/mbta.js
+++ b/lib/mbta.js
@@ -1,10 +1,51 @@
 'use strict'
 
-// Code here.
+let Red = ['South Station','Park Street','Kendall','Central','Harvard','Porter','Davis','Alewife']
+let Green = ['Government Center','Park Street','Boylston','Arlington','Copley','Hynes','Kenmore']
+let Orange = ['North Station','Haymarket','Park Street','State','Downtown Crossing','Chinatown','Backbay','Forest Hills']
+
+let mbta = {}
+mbta.Red = Red
+mbta.Green = Green
+mbta.Orange = Orange
+
+console.log(mbta)
 
 const stopsBetweenStations = (startLine, startStation, endLine, endStation) => {
+  if (startLine !== endLine){
+    let startIndex = mbta[startLine].indexOf(startStation)
+    let startParkIndex = mbta[startLine].indexOf('Park Street')
+    let startStopCount = Math.abs(startIndex - startParkIndex)
+    // console.log(startIndex)
+    // console.log(startParkIndex)
+    // console.log(startStopCount)
 
+    let endIndex = mbta[endLine].indexOf(endStation)
+    let endParkIndex = mbta[endLine].indexOf('Park Street')
+    let endStopCount = Math.abs(endIndex - endParkIndex)
+    // console.log(endIndex)
+    // console.log(endParkIndex)
+    // console.log(endStopCount)
+
+    let numStops = startStopCount + endStopCount
+    // console.log(numStops)
+    return numStops
+
+  }
+  else if (startLine === endLine) {
+    let startIndex = mbta[startLine].indexOf(startStation)
+    let endIndex = mbta[endLine].indexOf(endStation)
+    let numStops = Math.abs(startIndex - endIndex)
+    // console.log(startIndex)
+    // console.log(endIndex)
+    // console.log(numStops)
+
+    return numStops
+  }
 }
+
+
+stopsBetweenStations('Red','Harvard','Green','Arlington')
 
 module.exports = {
   stopsBetweenStations,

--- a/spec/mbta.spec.js
+++ b/spec/mbta.spec.js
@@ -17,14 +17,14 @@ describe('mbta', () => {
   })
 
   describe('Green Line', () => {
-    it('goes from "Haymarket" to "copley"', () => {
-      expect(mbta.stopsBetweenStations('Green', 'Government Center',
-        'Green', 'Kenmore')).to.equal(6)
+    it('goes from "Haymarket" to "Copley"', () => {
+      expect(mbta.stopsBetweenStations('Orange', 'Haymarket',
+        'Green', 'Copley')).to.equal(4)
     })
 
     it('goes from "Copley" to "Haymarket"', () => {
-      expect(mbta.stopsBetweenStations('Green', 'Kenmore',
-        'Green', 'Government Center')).to.equal(6)
+      expect(mbta.stopsBetweenStations('Green', 'Copley',
+        'Orange', 'Haymarket')).to.equal(4)
     })
   })
 


### PR DESCRIPTION
I think there might be an error in mbta.spec.js for tests 6 and 7:  'Haymarket to Copley' & 'Copley to Haymarket'.  The readout references 'Copley' and 'Haymarket', but the test itself tests 'Government Center' and 'Kenmore'.  I changed the tests to reflect Haymarket and Copley.  You can ignore my mbta.js file.